### PR TITLE
fix ability to build Unity projects

### DIFF
--- a/com.wug.behaviortreevisualizer/Editor/WhatUpGames.BehaviorTreeDebugger.Editor.asmdef
+++ b/com.wug.behaviortreevisualizer/Editor/WhatUpGames.BehaviorTreeDebugger.Editor.asmdef
@@ -3,7 +3,7 @@
     "references": [
         "GUID:2dd6cc2068976be4a8ca21e6105d86b0"
     ],
-    "includePlatforms": [],
+    "includePlatforms": ["Editor"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
- This was caused by the use of Assembly Definitions. Despite the Editor
  scripts being in the Editor folder, if Assembly Definitions are
  present, it will override the default behavior and include the
  assembly on all platforms, including non-editor platforms (builds)
- more info can be found at the following links:

https://docs.unity3d.com/2022.1/Documentation/Manual/ScriptCompilationAssemblyDefinitionFiles.html
https://answers.unity.com/questions/1571571/how-do-i-get-unity-to-not-include-editor-folder-in.html#
https://stackoverflow.com/a/64463571

accessed 8/31/2022